### PR TITLE
submodules: git clone using https instead of ssh

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,41 +1,41 @@
 [submodule "Odroid/odroid-go-firmware"]
 	path = Odroid/odroid-go-firmware
-	url = git@github.com:OtherCrashOverride/odroid-go-firmware.git
+	url = https://github.com/OtherCrashOverride/odroid-go-firmware.git
 	branch = esp-idf-v3.2
 [submodule "Launchers/emulator-launcher-odroid-go"]
 	path = Launchers/emulator-launcher-odroid-go
-	url = git@github.com:IlyaMZP/emulator-launcher-odroid-go.git
+	url = https://github.com/IlyaMZP/emulator-launcher-odroid-go.git
 [submodule "Emulators/prosystem-odroid-go"]
 	path = Emulators/prosystem-odroid-go
-	url = git@github.com:OtherCrashOverride/prosystem-odroid-go.git
+	url = https://github.com/OtherCrashOverride/prosystem-odroid-go.git
 [submodule "Emulators/stella-odroid-go"]
 	path = Emulators/stella-odroid-go
-	url = git@github.com:OtherCrashOverride/stella-odroid-go.git
+	url = https://github.com/OtherCrashOverride/stella-odroid-go.git
 [submodule "Emulators/frodo-go"]
 	path = Emulators/frodo-go
-	url = git@github.com:OtherCrashOverride/frodo-go.git
+	url = https://github.com/OtherCrashOverride/frodo-go.git
 [submodule "Emulators/go-play"]
 	path = Emulators/go-play
-	url = git@github.com:OtherCrashOverride/go-play.git
+	url = https://github.com/OtherCrashOverride/go-play.git
 [submodule "Emulators/odroid-go-pcengine-huexpress"]
 	path = Emulators/odroid-go-pcengine-huexpress
-	url = git@github.com:pelle7/odroid-go-pcengine-huexpress.git
+	url = https://github.com/pelle7/odroid-go-pcengine-huexpress.git
 [submodule "Emulators/super-go-play"]
 	path = Emulators/super-go-play
-	url = git@github.com:mattkj/super-go-play.git
+	url = https://github.com/mattkj/super-go-play.git
 [submodule "Emulators/pitpo"]
 	path = Emulators/pitpo
-	url = git@github.com:pitpo/go-play.git
+	url = https://github.com/pitpo/go-play.git
 [submodule "Emulators/odroid-go-spectrum-emulator"]
 	path = Emulators/odroid-go-spectrum-emulator
-	url = git@github.com:pelle7/odroid-go-spectrum-emulator.git
+	url = https://github.com/pelle7/odroid-go-spectrum-emulator.git
 	branch = feature/goemu
 [submodule "Emulators/odroid-go-handy"]
 	path = Emulators/odroid-go-handy
-	url = git@github.com:pelle7/odroid-go-handy.git
+	url = https://github.com/pelle7/odroid-go-handy.git
 	branch = develop
 [submodule "Emulators/retro-go"]
 	path = Emulators/retro-go
-	url = git@github.com:ducalex/retro-go.git
+	url = https://github.com/ducalex/retro-go.git
 	branch = master
 

--- a/DIY.md
+++ b/DIY.md
@@ -9,7 +9,7 @@ If you are considering / curious about the build process of the Retro ESP Launch
 Clone the **Master** [Official Retro ESP32](https://github.com/retro-esp32/RetroESP32/) repo
 
 ```shell
-git clone -b master --single-branch git@github.com:retro-esp32/RetroESP32.git --recursive
+git clone -b master --single-branch https://github.com/retro-esp32/RetroESP32.git --recursive
 cd RetroESP32
 git submodule update --init --recursive
 git submodule foreach git pull origin master


### PR DESCRIPTION
Due to ssh errors when running `git clone`, likes:
```
fatal: clone of 'git@github.com:IlyaMZP/emulator-launcher-odroid-go.git' into submodule path '/Users/kaotd/esp/esp-idf/RetroESP32/Launchers/emulator-launcher-odroid-go' failed
Failed to clone 'Launchers/emulator-launcher-odroid-go'. Retry scheduled
Cloning into '/Users/kaotd/esp/esp-idf/RetroESP32/Odroid/odroid-go-firmware'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.
```

I updated .gitmodules to fetch the repo using https instead of ssh.